### PR TITLE
specify api type

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -5,7 +5,7 @@
         "helper"
     ],
     "api": [
-        "native"
+        "rust"
     ],
     "description": "SigMaker style plugin",
     "license": {


### PR DESCRIPTION
Sorry about that, we just realized we should be specifying the API type since in the future the UI may allow filtering/searching based on that. 